### PR TITLE
Add support and tests for python version 3.6

### DIFF
--- a/.github/workflows/keep_a_changelog.yml
+++ b/.github/workflows/keep_a_changelog.yml
@@ -1,0 +1,15 @@
+name: "Changelog Reminder"
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: dangoslen/changelog-enforcer@v1.1.1
+      with:
+        changeLogPath: 'CHANGELOG.md'
+        skipLabel: 'Skip-Changelog'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest" ]
-        python-version: [ "3.7" ]
+        python-version: [ "3.6", "3.7" ]
     steps:
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ "ubuntu-latest" ]
-        python-version: [ "3.6", "3.7" ]
+        python-version: [ "3.7" ]
     steps:
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+About changelog [here](https://keepachangelog.com/en/1.0.0/)
+
+## [x.x.x]
+### Added
+
+### Fixed
+
+### Changed
+
+## [0.3]
+### Added
+- CHANGELOG.md
+- Workflow to check for CHANGELOG
+
+### Changed
+- Support for python >=3.6, <4

--- a/poetry.lock
+++ b/poetry.lock
@@ -344,9 +344,9 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "b0a798de7056c3cd2b255458c2809c521e3f95b91ed35d60d07899d4d33a44f7"
+content-hash = "81bc03066e31273cea4aa580fcb74d8ec4e273c643ec14f7356c12ae4ca23273"
 lock-version = "1.0"
-python-versions = "^3.6"
+python-versions = ">=3.6, <3.8"
 
 [metadata.files]
 atomicwrites = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -344,9 +344,9 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "81bc03066e31273cea4aa580fcb74d8ec4e273c643ec14f7356c12ae4ca23273"
+content-hash = "b0a798de7056c3cd2b255458c2809c521e3f95b91ed35d60d07899d4d33a44f7"
 lock-version = "1.0"
-python-versions = ">=3.6, <3.8"
+python-versions = "^3.6"
 
 [metadata.files]
 atomicwrites = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -96,6 +96,15 @@ requests = ">=1.0.0"
 yaml = ["PyYAML (>=3.10)"]
 
 [[package]]
+category = "main"
+description = "A backport of the dataclasses module for Python 3.6"
+marker = "python_version < \"3.7\""
+name = "dataclasses"
+optional = false
+python-versions = "*"
+version = "0.6"
+
+[[package]]
 category = "dev"
 description = "Pythonic argument parser, that will make you smile"
 name = "docopt"
@@ -189,6 +198,11 @@ name = "pydantic"
 optional = false
 python-versions = ">=3.6"
 version = "1.6.1"
+
+[package.dependencies]
+[package.dependencies.dataclasses]
+python = "<3.7"
+version = ">=0.6"
 
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
@@ -330,9 +344,9 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "48d67d4a1888c4eedb0756d3b62bba55f051431201f9d6f061ff6a8ed1997c3b"
+content-hash = "b0a798de7056c3cd2b255458c2809c521e3f95b91ed35d60d07899d4d33a44f7"
 lock-version = "1.0"
-python-versions = "^3.7"
+python-versions = "^3.6"
 
 [metadata.files]
 atomicwrites = [
@@ -402,6 +416,10 @@ coverage = [
 coveralls = [
     {file = "coveralls-2.1.2-py2.py3-none-any.whl", hash = "sha256:b3b60c17b03a0dee61952a91aed6f131e0b2ac8bd5da909389c53137811409e1"},
     {file = "coveralls-2.1.2.tar.gz", hash = "sha256:4430b862baabb3cf090d36d84d331966615e4288d8a8c5957e0fd456d0dd8bd6"},
+]
+dataclasses = [
+    {file = "dataclasses-0.6-py3-none-any.whl", hash = "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f"},
+    {file = "dataclasses-0.6.tar.gz", hash = "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"},
 ]
 docopt = [
     {file = "docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = ["Deployment",
             "Packaging"]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.6, <3.8"
 click = "^7.1.2"
 pydantic = "^1.6.1"
 coloredlogs = "^14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = ["Deployment",
             "Packaging"]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = ">=3.6, <3.8"
 click = "^7.1.2"
 pydantic = "^1.6.1"
 coloredlogs = "^14.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = ["Deployment",
             "Packaging"]
 
 [tool.poetry.dependencies]
-python = ">=3.6, <3.8"
+python = "^3.6"
 click = "^7.1.2"
 pydantic = "^1.6.1"
 coloredlogs = "^14.0"


### PR DESCRIPTION
### This PR adds | fixes:
- Support for python 3.6

**How to prepare for test**:
Tests are automated


### Review:
- [x] Code approved by MM
- [x] Tests executed by GithubActions
- [x] "Merge and deploy" approved by MM

This [version](https://semver.org/) is a:
- [x] **MINOR** - when you add functionality in a backwards compatible manner
